### PR TITLE
Fix 'Content-Length mismatch' error

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ var spamc = function (host, port, timeout) {
             cmd = cmd + " SPAMC/" + protocolVersion + "\r\n";
             if (typeof (message) == 'string') {
                 message = message + '\r\n';
-                cmd = cmd + "Content-length: " + (message.length) + "\r\n";
+                cmd = cmd + "Content-length: " + ( Buffer.byteLength(message) ) + "\r\n";
                 /* Process Extra Headers if Any */
                 if (typeof (extraHeaders) == 'object') {
                     for (var i = 0; i < extraHeaders.length; i++) {


### PR DESCRIPTION
I get errors like this: 
`[ 'SPAMD/1.0 76 Bad header line: (Content-Length mismatch: Expected 628 bytes, got 632 bytes)' ]` 
when the message contains multi-byte characters. String.prototype.length doesn't give the actual byte length
